### PR TITLE
Bump react-scripts version to 3.4.0

### DIFF
--- a/template.json
+++ b/template.json
@@ -23,7 +23,7 @@
       "react": "^16.12.0",
       "react-dom": "^16.12.0",
       "react-redux": "^7.1.3",
-      "react-scripts": "3.3.1",
+      "react-scripts": "^3.4.0",
       "redux": "^4.0.5",
       "redux-mock-store": "^1.5.4",
       "typescript": "~3.7.5"


### PR DESCRIPTION
Current version 3.3.1 produces an error when attempting to run react-scripts start. See [https://stackoverflow.com/a/60242323](https://stackoverflow.com/a/60242323). Bumping to 3.4.0 fixes the issue.